### PR TITLE
feat: implement listen for update notifications

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -30,7 +30,6 @@ func CreateRouter(apiStorage storage.APIStorage) *gin.Engine {
 	_, currentFile, _, _ := runtime.Caller(0)
 	r.StaticFile("/", path.Dir(currentFile)+"/static/index.html")
 	r.Static("/assets", path.Dir(currentFile)+"/static/assets")
-
 	apiV1 := r.Group("/v1")
 	{
 		apiV1.Use(CORSMiddleware())

--- a/pkg/api/v1/main.go
+++ b/pkg/api/v1/main.go
@@ -124,10 +124,15 @@ type InstanceInfo struct {
 	MaxJobs     int    `json:"maxJobs"`
 }
 
-func GetInstanceInfo(s storage.APIStorage) gin.HandlerFunc {
+type apiStatsStorage interface {
+	GetSSLVersion() (bool, string)
+	Connected() bool
+}
+
+func GetInstanceInfo(s apiStatsStorage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		cfg := config.FromEnvs()
-		dbConnected := s.GetClient().Stat().TotalConns() > 0
+		dbConnected := s.Connected()
 		tlsActive, tlsVersion := s.GetSSLVersion()
 		payload := &InstanceInfo{
 			cfg.AppName,

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -104,8 +104,8 @@ func (j *Job) Schedule(notifier chan int) string {
 	timer := time.After(nextExecution.Sub(now))
 	select {
 	case <-j.AbortChannel:
-		j.Scheduled = false
 		return "aborted"
+
 	case executionTime := <-timer:
 		result := j.Execute()
 		j.LastResponseAt = result.ResponseTime
@@ -122,6 +122,7 @@ func (j *Job) Schedule(notifier chan int) string {
 		}
 		notifier <- j.Id
 	}
+
 	return "re-schedule"
 
 }

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -193,6 +193,5 @@ func TestAbortJob(t *testing.T) {
 	}()
 	j.AbortChannel <- struct{}{}
 	wg.Wait()
-	assert.False(t, j.Scheduled)
 	assert.False(t, executorTriggered)
 }

--- a/pkg/storage/getAvailableJobs.go
+++ b/pkg/storage/getAvailableJobs.go
@@ -16,16 +16,13 @@ import (
 func (sqls *SQLStorage) GetAvailableJobs(limit int) []*job.Job {
 	ctx := context.Background()
 	tx, err := sqls.Db.Begin(ctx)
-
 	if err != nil {
 		log.Error().Err(err).Msg("could not start transaction to get available jobs")
 		return nil
 	}
-
 	defer tx.Rollback(ctx)
-
 	rows, err := tx.Query(ctx, `
-SELECT 
+SELECT
 	id,
 	cron_exp_string,
 	endpoint,
@@ -42,6 +39,7 @@ SELECT
 	created_at
  FROM jobs 
  WHERE status = 'pending to be claimed' 
+ FOR UPDATE SKIP LOCKED
  LIMIT  $1;`, limit)
 
 	if err != nil {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -19,6 +19,9 @@ type Storage interface {
 }
 
 type SchedulerStorage interface {
+	ListenForChanges(ch chan int, ctx context.Context)
+	StopListeningForChanges() error
+	GetJobUpdates(jobId int) *JobUpdates
 	GetAvailableJobs(limit int) []*job.Job
 	WriteDone(*job.Job) error
 	RegisterSelf()
@@ -29,7 +32,7 @@ type SchedulerStorage interface {
 type APIStorage interface {
 	GetClaimedJobs(limit int, offset int) []*job.Job
 	GetClaimedJobsExecutions(jobId int, limit int, offset int) []*job.JobExecution
-	GetClient() *pgxpool.Pool
+	Connected() bool
 	GetSSLVersion() (bool, string)
 }
 
@@ -42,6 +45,10 @@ type Closer func()
 // Returns the raw client
 func (sqls *SQLStorage) GetClient() *pgxpool.Pool {
 	return sqls.Db
+}
+
+func (sqls *SQLStorage) Connected() bool {
+	return sqls.Db.Ping(context.Background()) == nil
 }
 
 // Should register the url, name of the application and so on in the db

--- a/pkg/storage/updates.go
+++ b/pkg/storage/updates.go
@@ -1,0 +1,148 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+
+	"github.com/back-end-labs/ruok/pkg/config"
+	"github.com/rs/zerolog/log"
+)
+
+func (s *SQLStorage) StopListeningForChanges() error {
+	ctx := context.Background()
+	_, err := s.Db.Exec(ctx, "unlisten "+config.AppName())
+	if err != nil {
+		log.Error().Err(err).Msg("could not send unlisten command to db")
+		return err
+	}
+	return nil
+}
+
+// Creates a gorutine that waits for messages in a loop and sends them over "jobIDUpdatedCh".
+//
+// It will block until the waiting loop starts
+func (s *SQLStorage) ListenForChanges(jobIDUpdatedCh chan int, ctx context.Context) {
+	ready := make(chan struct{})
+
+	go func(jobIDUpdatedCh chan int, ctx context.Context) {
+		ownChannel := config.AppName()
+		conn, err := s.Db.Acquire(context.Background())
+
+		if err != nil {
+			log.Error().Err(err).Msg("could not acquire connection to listen for notifications")
+			return
+		}
+		defer conn.Release()
+
+		_, err = conn.Exec(context.Background(), "listen "+config.AppName())
+
+		if err != nil {
+			log.Error().Err(err).Msgf("could not listen to %q channel", ownChannel)
+			return
+		}
+
+		ready <- struct{}{}
+		for {
+			notification, err := conn.Conn().WaitForNotification(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					log.Info().Msg("done listening for notifications")
+					break
+				}
+				log.Error().Err(err).Msgf("an error occurred while listening into %q channel", ownChannel)
+				break
+			}
+			if notification.Payload == "release" {
+				log.Info().Msg("Received release, done!")
+				return
+			}
+			if notification == nil {
+				log.Info().Msg("empty notification")
+				continue
+			}
+			id, err := strconv.ParseInt(notification.Payload, 10, 64)
+			if err != nil {
+				log.Error().Err(err).Msgf("an error occurred while parsing payload into job id %q for job update", notification.Payload)
+				continue
+			}
+			jobIDUpdatedCh <- int(id)
+		}
+	}(jobIDUpdatedCh, ctx)
+
+	<-ready
+	close(ready)
+
+}
+
+const getJobsUpdatesQuery = `
+SELECT 
+	cron_exp_string,
+	endpoint,
+	httpmethod,
+	max_retries,
+	headers_string,
+	success_statuses,
+	tls_client_cert,
+	updated_at
+FROM jobs
+WHERE id = $1
+`
+
+type JobUpdates struct {
+	Cron_exp_string  string
+	Endpoint         string
+	Httpmethod       string
+	Max_retries      int
+	Headers_string   sql.NullString
+	Success_statuses []int
+	Tls_client_cert  sql.NullString
+	Updated_at       int64
+}
+
+func (s *SQLStorage) GetJobUpdates(jobId int) *JobUpdates {
+	ctx := context.Background()
+	tx, err := s.Db.Begin(ctx)
+	if err != nil {
+		log.Error().Err(err).Msgf("could not begin transaction to get updates for job %d", jobId)
+		return nil
+	}
+	defer tx.Rollback(ctx)
+
+	row := tx.QueryRow(ctx, getJobsUpdatesQuery, jobId)
+
+	var cron_exp_string string
+	var endpoint string
+	var httpmethod string
+	var max_retries int
+	var headers_string sql.NullString
+	var success_statuses []int
+	var tls_client_cert sql.NullString
+	var updated_at sql.NullInt64
+
+	err = row.Scan(
+		&cron_exp_string,
+		&endpoint,
+		&httpmethod,
+		&max_retries,
+		&headers_string,
+		&success_statuses,
+		&tls_client_cert,
+		&updated_at,
+	)
+
+	if err != nil {
+		log.Error().Err(err).Msgf("could not scan row to get updates for job %d", jobId)
+		return nil
+	}
+	return &JobUpdates{
+		cron_exp_string,
+		endpoint,
+		httpmethod,
+		max_retries,
+		headers_string,
+		success_statuses,
+		tls_client_cert,
+		updated_at.Int64,
+	}
+}

--- a/pkg/storage/updates_test.go
+++ b/pkg/storage/updates_test.go
@@ -1,0 +1,109 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/back-end-labs/ruok/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListenForChanges(t *testing.T) {
+	cfg := config.FromEnvs()
+	s, closeDbCon := NewStorage(&cfg)
+	defer closeDbCon()
+	ch := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	s.ListenForChanges(ch, ctx)
+	signals := []string{"0", "1", "2", "3", "4", "5"}
+	for i, sig := range signals {
+		ctx := context.Background()
+		_, err := s.GetClient().Exec(ctx, "select pg_notify($1, $2)", config.AppName(), sig)
+		if err != nil {
+			t.Errorf("could not send test message: %q", err.Error())
+		}
+		v := <-ch
+		assert.Equal(t, i, v)
+	}
+	cancel()
+	s.StopListeningForChanges()
+}
+
+func TestGetJobUpdates(t *testing.T) {
+	var seedOneJobQuery = `
+INSERT INTO jobs (
+	id,
+	cron_exp_string,
+	endpoint,
+	httpmethod,
+	max_retries,
+	success_statuses,
+	status,
+	claimed_by
+) VALUES (1,'* * * * *', '/', 'GET', 1, '{200}',  'claimed','application1')
+`
+	cfg := config.FromEnvs()
+	s, closeDbCon := NewStorage(&cfg)
+	defer closeDbCon()
+	_, err := s.GetClient().Exec(context.Background(), seedOneJobQuery)
+	if err != nil {
+		t.Errorf("couldn't seed one job for the test, %q", err.Error())
+		t.FailNow()
+	}
+
+	new_cron_exp_string := "0 * * * * *"
+	new_endpoint := "/slash"
+	new_httpmethod := "POST"
+	new_max_retries := 3
+	new_headers_string := "{}"
+	new_success_statuses := []int{200, 201}
+	new_tls_client_cert := "a cert"
+	new_updated_at := time.Now().UnixMicro()
+
+	_, err = s.GetClient().Exec(context.Background(), `
+		UPDATE jobs SET 
+			cron_exp_string = $1,
+			endpoint = $2,
+			httpmethod = $3,
+			max_retries = $4,
+			headers_string = $5,
+			success_statuses = $6,
+			tls_client_cert = $7,
+			updated_at = $8
+		WHERE id = $9`,
+		new_cron_exp_string,
+		new_endpoint,
+		new_httpmethod,
+		new_max_retries,
+		new_headers_string,
+		new_success_statuses,
+		new_tls_client_cert,
+		new_updated_at,
+		1,
+	)
+	if err != nil {
+		t.Errorf("couldn't update one job for the test, %q", err.Error())
+		t.FailNow()
+	}
+	j := s.GetJobUpdates(1)
+
+	assert.NotNil(t, j, "GetJobUpdates should return a non-nil JobUpdates instance")
+	assert.Equal(t, new_cron_exp_string, j.Cron_exp_string, "Unexpected cron_exp_string")
+	assert.Equal(t, new_endpoint, j.Endpoint, "Unexpected endpoint")
+	assert.Equal(t, new_httpmethod, j.Httpmethod, "Unexpected httpmethod")
+	assert.Equal(t, new_max_retries, j.Max_retries, "Unexpected max_retries")
+	assert.Equal(t, new_headers_string, j.Headers_string.String, "Unexpected headers_string")
+	assert.Equal(t, new_success_statuses, j.Success_statuses, "Unexpected success_statuses")
+	assert.Equal(t, new_tls_client_cert, j.Tls_client_cert.String, "Unexpected tls_client_cert")
+	assert.Equal(t, new_updated_at, j.Updated_at, "Unexpected updated_at")
+}
+
+func TestStopListening(t *testing.T) {
+	cfg := config.FromEnvs()
+	s, closeDbCon := NewStorage(&cfg)
+	err := s.StopListeningForChanges()
+	assert.NoError(t, err)
+	closeDbCon()
+	assert.Error(t, s.StopListeningForChanges())
+}

--- a/pkg/storage/writeDone_test.go
+++ b/pkg/storage/writeDone_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/back-end-labs/ruok/pkg/job"
 )
 
-var seedWriteDoneQuery = `
+var seedOneJobQuery = `
 INSERT INTO jobs (
 	id,
 	cron_exp_string,
@@ -82,7 +82,7 @@ func TestWriteDone(t *testing.T) {
 
 		ctx := context.Background()
 
-		_, err := s.GetClient().Exec(ctx, seedWriteDoneQuery)
+		_, err := s.GetClient().Exec(ctx, seedOneJobQuery)
 
 		if err != nil {
 			t.Errorf("couln't seed due to the following error: %q", err.Error())


### PR DESCRIPTION
- misc changes:
  * Refactored main function a little bit
  * Added missing test for GetInstanceStats endpoint
  * Changed how we check if DB is connected (now we ping)
  * Now apiStats expets its own reduced storage interface
  * Added Validation to restrict app names only to letters, numbers and low dashes
  * Added TestIsInvalidAppName function in config package
  * Jobs no longer sets their own state to scheduled or not scheduled, the scheduler does it
  * Added locks to prevent race conditions while modifying jobs in the joblist
  * Moved the jobDone notifier to a private field in scheduler struct
  * refactored operations in their own private scheduler methods

- notifications changes:
  * Get available jobs now locks rows for the transaction, also skip locked ones
  * Added three new methods to listen for changes, stop listening, and get job updates
  * Added test for the three
  * Updated "start" scheduler method to handle notifications and re-schedules